### PR TITLE
feat:imageUploadBox 구현

### DIFF
--- a/src/components/common/ImageUploadBox.tsx
+++ b/src/components/common/ImageUploadBox.tsx
@@ -1,0 +1,34 @@
+interface ImageUploadBoxProps {
+  className?: string;
+  textClassName?: string;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+function ImageUploadBox({
+  className = "",
+  textClassName = "",
+  disabled = false,
+  onClick,
+}: ImageUploadBoxProps) {
+  return (
+    <div
+      className={`ct-center flex-col whitespace-pre-line ${
+        disabled ? `cursor-not-allowed` : `cursor-pointer`
+      } ${className}`}
+      onClick={!disabled ? onClick : undefined}
+    >
+      <div className="w-[27px] h-[27px] ct-center bg-ct-white rounded-full text-[24px] text-gray-100">
+        +
+      </div>
+      <div
+        className={`mt-[9.29px] text-center leading-normal ${textClassName}`}
+      >
+        클릭하여 사진을
+        <br />
+        추가해보세요!
+      </div>
+    </div>
+  );
+}
+export default ImageUploadBox;


### PR DESCRIPTION
## 📌 PR 제목

- feat: ImageUploadBox 구현

## ✅ 작업 내용

- ImageUploadBox 구현(현재는 이미지 업로드 버튼만 존재하고 업로드 기능은 추후 추가)

## 🔍 확인 사항

- 피그마 기준 약 5군데 정도 사용되는 컴포넌트로 컨테이너 크기가 다 달라서 className props를 통해서 크기 설정 후 사용가능
- text의 내용은 같은데 크기가 달라서 textClassName props를 통해서 text 크기 설정가능
-사용 예시
<ImageUploadBox
            className="w-[349px] h-[384px] rounded-[16px] bg-ct-gray-100"
            textClassName="text-body2 font-Pretendard text-ct-gray-300"
          />
