### PR TITLE
feat:리크루팅 공고 등록 페이지 구현

### DIFF
--- a/src/components/recruiting/InputField.tsx
+++ b/src/components/recruiting/InputField.tsx
@@ -1,0 +1,20 @@
+interface InputFieldProps {
+  label: string;
+  placeholder?: string;
+}
+
+function InputField({ label, placeholder }: InputFieldProps) {
+  return (
+    <div className="flex flex-col gap-[13.15px] mb-[24.85px]">
+      <label className="pl-[7px] text-sub1 text-ct-black-200 font-Pretendard">
+        {label}
+      </label>
+      <input
+        type="text"
+        placeholder={placeholder}
+        className="text-[15px] font-[400] placeholder:text-ct-gray-300 text-ct-black-200 font-Pretendard w-full min-h-[44px] rounded-[10px] pl-[26px] bg-ct-gray-100"
+      />
+    </div>
+  );
+}
+export default InputField;

--- a/src/pages/recruiting/RegisterAnnouncement.tsx
+++ b/src/pages/recruiting/RegisterAnnouncement.tsx
@@ -1,0 +1,47 @@
+import BottomCTAButton from "../../components/common/BottomCTAButton";
+import ImageUploadBox from "../../components/common/ImageUploadBox";
+import TopBar from "../../components/common/TopBar";
+import InputField from "../../components/recruiting/InputField";
+
+function RegisterAnnouncement() {
+  return (
+    <>
+      <TopBar>
+        <span className="text-h2 font-Pretendard text-ct-black-300">
+          공고 등록
+        </span>
+      </TopBar>
+      <div className="flex flex-col pt-[90px] mx-[19px]">
+        <InputField label="공고 제목" placeholder="입력해주세요" />
+        <InputField label="구인 직무" placeholder="입력해주세요" />
+        <InputField
+          label="근무 지역"
+          placeholder="추후 드롭다운 박스로 구현 예정"
+        />
+        <InputField label="지원 조건" placeholder="입력해주세요" />
+        <InputField label="급여" placeholder="추후 드롭다운 박스로 구현 예정" />
+        <InputField label="근무 형태" placeholder="선택" />
+        <InputField
+          label="마감 일자"
+          placeholder="추후 드롭다운 박스로 구현 예정"
+        />
+        <div className="flex flex-col gap-[13.15px] mt-[25px]">
+          <span className="pl-[7px] text-sub1 text-ct-black-200 font-Pretendard">
+            공고사진 첨부
+          </span>
+          <ImageUploadBox
+            className="w-[349px] h-[384px] rounded-[16px] bg-ct-gray-100"
+            textClassName="text-body2 font-Pretendard text-ct-gray-300"
+          />
+        </div>
+        <span className="mt-[25px] mb-[23.29px] text-body1 text-ct-gray-300 ">
+          등록된 공고는 ‘마이페이지’, ‘공고 관리’ 탭에서 확인 가능합니다.
+        </span>
+        <div className="flex justify-center mb-[42px]">
+          <BottomCTAButton text="공고 등록하기" />
+        </div>
+      </div>
+    </>
+  );
+}
+export default RegisterAnnouncement;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -7,6 +7,8 @@ import Recruiting from "../pages/recruiting/Recruiting";
 import Splash from "../pages/onboarding/Splash";
 import RecruitAnnouncement from "../pages/recruiting/RecruitAnnouncement";
 import SelectMembers from "../pages/onboarding/SelectMembers";
+import SavedAnnouncement from "../pages/recruiting/SavedAnnouncement";
+import RegisterAnnouncement from "../pages/recruiting/RegisterAnnouncement";
 
 const router = createBrowserRouter([
   {
@@ -32,6 +34,14 @@ const router = createBrowserRouter([
       {
         path: "recruit/announcement",
         element: <RecruitAnnouncement />,
+      },
+      {
+        path: "recruit/savedannouncement",
+        element: <SavedAnnouncement />,
+      },
+      {
+        path: "recruit/registerannouncement",
+        element: <RegisterAnnouncement />,
       },
       {
         path: "onboarding",


### PR DESCRIPTION
## 📌 PR 제목

- feat: 리크루팅 공고 등록 페이지 구현 

## ✅ 작업 내용

- inputfield 컴포넌트를 통해서 리크루팅 공고 등록 페이지 구현

## 🔍 확인 사항

- 드롭다운 박스도 일단은 inputfield로 구현 추후 드롭다운 박스로 수정 예정
- placeholder 색상과 text를 입력하였을때 글자 색상 다르게 설정 완료