### PR TITLE
feat: 댓글 무한스크롤 구현 및 프로필 네비게이션 개선

### DIFF
--- a/src/apis/feed.ts
+++ b/src/apis/feed.ts
@@ -38,11 +38,34 @@ export const removeFeedLike = async (feedId: number): Promise<LikeFeedResponse> 
 // 피드 댓글 목록 조회
 export const getFeedComments = async ({ feedId, last_comment_id, size }: GetCommentsParams): Promise<CommentsResponse> => {
   const params: Record<string, string | number> = {};
-  if (last_comment_id) params.last_comment_id = last_comment_id;
+  // first page에서는 last_comment_id를 전달하지 않음
+  if (last_comment_id !== undefined) {
+    params.last_comment_id = last_comment_id;
+  }
   if (size) params.size = size;
   
-  const response = await apiClient.get<CommentsResponse>(`/api/feeds/${feedId}/comments`, { params });
-  return response.data;
+  const isFirstPage = last_comment_id === undefined;
+  console.log(`🔄 [API] 댓글 조회 요청 ${isFirstPage ? '(첫 페이지)' : '(다음 페이지)'}:`, { 
+    feedId, 
+    last_comment_id, 
+    size, 
+    params,
+    url: `/api/feeds/${feedId}/comments`
+  });
+  
+  try {
+    const response = await apiClient.get<CommentsResponse>(`/api/feeds/${feedId}/comments`, { params });
+    console.log('✅ [API] 댓글 조회 응답 성공:', response.data);
+    return response.data;
+  } catch (error: any) {
+    console.error('❌ [API] 댓글 조회 실패:', {
+      feedId,
+      last_comment_id,
+      params,
+      error: error.response?.data || error.message
+    });
+    throw error;
+  }
 };
 
 // 댓글 작성

--- a/src/components/feed/FixedHeader.tsx
+++ b/src/components/feed/FixedHeader.tsx
@@ -4,8 +4,8 @@ function FixedHeader() {
   const navigate = useNavigate(); // ✅ 훅 사용
 
   return (
-    <div className="fixed top-0 left-0 w-full bg-white z-50 shadow ">
-      <div className="fixed top-0 left-0 w-full h-[66px] bg-white z-50 flex items-center justify-between px-[30px] shadow">
+    <div className="fixed top-0 left-0 w-full bg-white z-40 shadow ">
+      <div className="fixed top-0 left-0 w-full h-[66px] bg-white z-40 flex items-center justify-between px-[30px] shadow">
         <img
           src="/assets/common/headerLogo.svg"
           alt="MyFit"

--- a/src/contexts/SignupContext.tsx
+++ b/src/contexts/SignupContext.tsx
@@ -20,6 +20,7 @@ interface SignupData {
   highSector: string;
   lowSector: string;
   gradeStatus: string;
+  educationLevel: string; // 최종 학력
   
   // 회사 회원 전용 필드
   teamDivision: string; // 스타트업/창업 팀/예비 창업팀
@@ -69,6 +70,7 @@ const initialSignupData: SignupData = {
   highSector: '',
   lowSector: '',
   gradeStatus: '',
+  educationLevel: '',
   
   // 회사 회원 전용 필드
   teamDivision: '',

--- a/src/hooks/feed/useFeedComments.ts
+++ b/src/hooks/feed/useFeedComments.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { getFeedComments } from "../../apis/feed";
 
 interface UseFeedCommentsProps {
@@ -6,9 +6,32 @@ interface UseFeedCommentsProps {
 }
 
 export const useFeedComments = ({ activePostId }: UseFeedCommentsProps) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ["comments", activePostId],
-    queryFn: () => getFeedComments({ feedId: Number(activePostId) }),
+    queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
+      getFeedComments({
+        feedId: Number(activePostId),
+        last_comment_id: pageParam,
+        size: 10,
+      }),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => {
+      const comments = lastPage.result.feeds;
+      console.log('🔄 [Pagination] getNextPageParam 체크:', {
+        commentsLength: comments.length,
+        hasMore: comments.length === 10,
+        lastCommentId: comments.length > 0 ? comments[comments.length - 1].id : null
+      });
+      
+      if (comments.length === 10) {
+        const nextPageParam = comments[comments.length - 1].id;
+        console.log('➡️ [Pagination] 다음 페이지 파라미터:', nextPageParam);
+        return nextPageParam;
+      }
+      
+      console.log('🏁 [Pagination] 마지막 페이지 도달');
+      return undefined;
+    },
     enabled: !!activePostId,
   });
 };

--- a/src/pages/feed/FeedPage.tsx
+++ b/src/pages/feed/FeedPage.tsx
@@ -35,7 +35,12 @@ export default function FeedPage() {
     handleCommentDelete,
   } = useFeedMutations({ activePostId });
 
-  const { data: commentsData } = useFeedComments({ activePostId });
+  const {
+    data: commentsData,
+    fetchNextPage: fetchCommentsNextPage,
+    hasNextPage: hasCommentsNextPage,
+    isFetchingNextPage: isFetchingCommentsNextPage,
+  } = useFeedComments({ activePostId });
 
   const { loadMoreRef } = useInfiniteScroll({
     hasNextPage: !!hasNextPage,
@@ -81,11 +86,14 @@ export default function FeedPage() {
                 onProfileClick={() => {
                   console.log("프로필 클릭됨:", feed.user);
                   if (feed.user?.id) {
+                    // 내가 작성한 피드라면 마이페이지로, 다른 사람 피드라면 해당 사용자 프로필로 이동
+                    const isMyFeed = feed.user.id === user?.id;
+                    const targetPath = isMyFeed ? "/mypage" : `/feed/profile/${feed.user.id}`;
                     console.log(
-                      "프로필 페이지로 이동:",
-                      `/feed/profile/${feed.user.id}`
+                      `${isMyFeed ? '마이페이지' : '프로필 페이지'}로 이동:`,
+                      targetPath
                     );
-                    navigate(`/feed/profile/${feed.user.id}`);
+                    navigate(targetPath);
                   }
                 }}
               />
@@ -122,13 +130,16 @@ export default function FeedPage() {
             />
             <CommentModal
               postId={activePostId}
-              comments={commentsData?.result?.feeds || []}
+              comments={commentsData?.pages.flatMap(page => page.result.feeds) || []}
               onClose={() => setActivePostId(null)}
               onCommentCreate={handleCommentCreate}
               onReplyCreate={handleReplyCreate}
               onCommentDelete={handleCommentDelete}
               currentUserId={user?.id}
               postOwnerId={allFeeds.find(feed => feed.feed_id === Number(activePostId))?.user?.id}
+              fetchNextPage={fetchCommentsNextPage}
+              hasNextPage={hasCommentsNextPage}
+              isFetchingNextPage={isFetchingCommentsNextPage}
             />
           </>
         )}

--- a/src/pages/feed/FeedSearchResult.tsx
+++ b/src/pages/feed/FeedSearchResult.tsx
@@ -59,7 +59,12 @@ const FeedSearchResult = () => {
       : ["searchFeedsByKeyword", keyword]
   });
 
-  const { data: commentsData } = useFeedComments({ activePostId });
+  const {
+    data: commentsData,
+    fetchNextPage: fetchCommentsNextPage,
+    hasNextPage: hasCommentsNextPage,
+    isFetchingNextPage: isFetchingCommentsNextPage,
+  } = useFeedComments({ activePostId });
 
   const { loadMoreRef } = useInfiniteScroll({
     hasNextPage: !!hasNextPage,
@@ -195,7 +200,10 @@ const FeedSearchResult = () => {
             onLikeClick={() => handleLikeToggle(feed.feed_id, feed.is_liked)}
             onProfileClick={() => {
               if (feed.user?.id) {
-                navigate(`/feed/profile/${feed.user.id}`);
+                // 내가 작성한 피드라면 마이페이지로, 다른 사람 피드라면 해당 사용자 프로필로 이동
+                const isMyFeed = feed.user.id === user?.id;
+                const targetPath = isMyFeed ? "/mypage" : `/feed/profile/${feed.user.id}`;
+                navigate(targetPath);
               }
             }}
           />
@@ -223,13 +231,16 @@ const FeedSearchResult = () => {
             />
             <CommentModal
               postId={activePostId}
-              comments={commentsData?.result?.feeds || []}
+              comments={commentsData?.pages.flatMap(page => page.result.feeds) || []}
               onClose={() => setActivePostId(null)}
               onCommentCreate={handleCommentCreate}
               onReplyCreate={handleReplyCreate}
               onCommentDelete={handleCommentDelete}
               currentUserId={user?.id}
               postOwnerId={allFeeds.find(feed => feed.feed_id === Number(activePostId))?.user?.id}
+              fetchNextPage={fetchCommentsNextPage}
+              hasNextPage={hasCommentsNextPage}
+              isFetchingNextPage={isFetchingCommentsNextPage}
             />
           </>
         )}

--- a/src/pages/onboarding/CompanyProfileRegister.tsx
+++ b/src/pages/onboarding/CompanyProfileRegister.tsx
@@ -54,8 +54,8 @@ function CompanyProfileRegister() {
         division: "team",
         name: companyName,
         one_line_profile: shortIntro,
-        high_area_id: signupData.highAreaId || 1, // ID로 전송
-        low_area_id: signupData.lowAreaId || 1,   // ID로 전송
+        high_area: region,
+        low_area: subRegion,
         recruiting_status: employmentStatus,
         team_division: division,
         industry: industry,

--- a/src/pages/onboarding/ProfileRegister.tsx
+++ b/src/pages/onboarding/ProfileRegister.tsx
@@ -26,7 +26,7 @@ function ProfileRegister() {
   const [subRegionError, setSubRegionError] = useState("");
   const [birthDate, setBirthDate] = useState(signupData.birthdate || "");
   const [employ, setEmploy] = useState(signupData.recruitingStatus || "");
-  const [educationLevel, setEducationLevel] = useState("");
+  const [educationLevel, setEducationLevel] = useState(signupData.educationLevel || "");
   const [highSector, setHighSector] = useState<string[]>([]);
   const [lowSector, setLowSector] = useState<string[]>([]);
   const [academic, setAcademic] = useState(signupData.gradeStatus || "");
@@ -137,7 +137,17 @@ function ProfileRegister() {
             label="희망 직무를 선택해주세요"
             value={selectedSkillLabel}
             placeholder="희망직무 입력"
-            onClick={() =>
+            onClick={() => {
+              // Context에 현재 상태 먼저 저장
+              updateProfileInfo({
+                name: nickname,
+                oneLineProfile: shortIntro,
+                birthdate: birthDate,
+                recruitingStatus: employ,
+                gradeStatus: academic,
+                educationLevel: educationLevel,
+              });
+              
               nav("/onboarding/jobpreference", {
                 state: {
                   from: "onboarding",
@@ -154,8 +164,8 @@ function ProfileRegister() {
                   high_sector: highSector,
                   low_sector: lowSector,
                 },
-              })
-            }
+              });
+            }}
           />
           <PersonalInputField
             label="최종 학력을 입력해주세요"
@@ -185,6 +195,7 @@ function ProfileRegister() {
                   birthdate: birthDate,
                   recruitingStatus: employ,
                   gradeStatus: academic,
+                  educationLevel: educationLevel,
                   highSector: highSector.join(", ") || "",
                   lowSector: lowSector.join(", ") || "",
                 });
@@ -197,11 +208,12 @@ function ProfileRegister() {
                   name: nickname,
                   one_line_profile: shortIntro,
                   birth_date: birthDate,
-                  high_area_id: signupData.highAreaId || 1, // 기본값 설정 필요
-                  low_area_id: signupData.lowAreaId || 1, // 기본값 설정 필요
+                  high_area: region,
+                  low_area: subRegion,
                   recruiting_status: employ,
                   high_sector: highSector[0] || "",
                   low_sector: lowSector.join(", ") || "",
+                  Highest_grade: educationLevel,
                   grade_status: academic,
                 };
 

--- a/src/types/onboarding/companyProfile.ts
+++ b/src/types/onboarding/companyProfile.ts
@@ -4,8 +4,8 @@ export interface CompanyProfileRequest {
   division: "team";
   name: string;
   one_line_profile?: string;
-  high_area_id: number; // 개인 회원가입과 동일하게 ID로 변경
-  low_area_id: number;  // 개인 회원가입과 동일하게 ID로 변경
+  high_area: string;
+  low_area: string;
   recruiting_status?: string;
   team_division?: string; // 스타트업/창업 팀/예비 창업팀
   industry?: string; // 업종

--- a/src/types/onboarding/signup.ts
+++ b/src/types/onboarding/signup.ts
@@ -5,11 +5,12 @@ export interface SignUpRequest {
   name: string;
   one_line_profile?: string;
   birth_date?: string; // YYYY-MM-DD 형식
-  high_area_id: number;
-  low_area_id: number;
+  high_area: string;
+  low_area: string;
   recruiting_status?: string;
   high_sector?: string;
   low_sector?: string;
+  Highest_grade?: string;
   grade_status?: string;
 }
 


### PR DESCRIPTION
- 댓글 시스템을 무한스크롤로 변경하여 11개 이상 댓글 표시 문제 
- useFeedComments를 useInfiniteQuery로 변경
- CommentModal에 Intersection Observer 기반 무한스크롤 추가
- 댓글 API 파라미터 처리 개선 및 디버깅 로그 추가
- 자신의 피드/댓글 프로필 클릭 시 마이페이지(/mypage)로 이동하도록 조건부 로직 추가
- SignupContext에 educationLevel 필드 추가하여 네비게이션 시 데이터 손실 방지
- 회원가입 API 요청 시 지역 정보 필드명 수정 (high_area_id → high_area)

## 📌 PR 제목

- feat: 로그인 페이지 구현

## ✅ 작업 내용

- 로그인 UI 구현
- 상태 관리 및 유효성 검사 추가
- 테스트 코드 작성

## 🔍 확인 사항

- [ ] 디자인과 일치하는지 확인
- [ ] 모바일 해상도에서 정상 동작
- [ ] 로그인 실패 시 에러 메시지 확인됨

## 📷 스크린샷

(필요 시 캡처 첨부)

## 💬 기타 논의사항

- 리팩토링은 이후 별도 브랜치에서 진행 예정
